### PR TITLE
Fix bug with item pull

### DIFF
--- a/tasks/present.yml
+++ b/tasks/present.yml
@@ -34,7 +34,7 @@
       dockerfile: >
         {{ item.item.dockerfile
         | default(item.invocation.module_args.dest) }}
-      pull: "{{ item.pull | default(true) }}"
+      pull: "{{ item.item.pull | default(true) }}"
     force_source: "{{ item.item.force | default(true) }}"
   with_items: "{{ platforms.results }}"
   when: >-


### PR DESCRIPTION
The `Build Ansible compatible image` step always attempts to pull the image.  This fixes that bug so that the user can specify `pull` in their `molecule.yml`.